### PR TITLE
Get start and end date with date fns instead of split to avoid wrongl…

### DIFF
--- a/hat-menu/src/data/menusApi.ts
+++ b/hat-menu/src/data/menusApi.ts
@@ -2,6 +2,7 @@ import { useSupabaseQuery, useSupabaseMutation } from './useSupabaseQuery';
 import { supabase } from '../supabase-config';
 import type { Menu, MenuInsert, MenuWithRecipes, MenuRecipeInsert } from '../schemas/supabase-helpers';
 import type { MenuForm } from '../schemas/Menus';
+import { format } from 'date-fns';
 
 
 function useMenus() {
@@ -36,8 +37,8 @@ async function addMenu(menu: MenuForm): Promise<Menu | null> {
         const { data: menuData, error: menuError } = await supabase
             .from('menu')
             .insert({
-                startDate: menu.startDate.toISOString().split('T')[0],
-                endDate: menu.endDate.toISOString().split('T')[0],
+                startDate: format(menu.startDate, 'yyyy-MM-dd'),
+                endDate: format(menu.endDate, 'yyyy-MM-dd')
             })
             .select()
             .single();


### PR DESCRIPTION
…y using time zone

The start and end dates in the form are Date objects with time set to midnight. Using `.toIsoString()` transforms the Date into a string **in UTC**, which took our dates to the previous day's 9pm.
Using proper date-fns makes this safer.