### PR TITLE
Fix/recipe form UI url not optional duplicated errors

### DIFF
--- a/hat-menu/src/components/AddRecipeForm.tsx
+++ b/hat-menu/src/components/AddRecipeForm.tsx
@@ -57,12 +57,13 @@ const AddRecipeForm = () => {
                 />
             </div>
             <div>
-                <label htmlFor="recipe-url">Recipe URL (optional):</label>
+                <label htmlFor="recipe-url">Recipe URL:</label>
                 <input
                     type="text"
                     id="recipe-url"
                     aria-describedby='error-url'
                     autoComplete="off"
+                    required
                     {...register('url')}
                 />
             </div>
@@ -75,6 +76,7 @@ const AddRecipeForm = () => {
                     rows={4}
                     cols={50}
                     placeholder="Enter ingredients (e.g., 2 cups flour, 1 tsp salt, 3 eggs)"
+                    required
                     {...register('ingredients')}
                 />
                 {errors.ingredients && (

--- a/hat-menu/src/components/AddRecipeForm.tsx
+++ b/hat-menu/src/components/AddRecipeForm.tsx
@@ -79,11 +79,6 @@ const AddRecipeForm = () => {
                     required
                     {...register('ingredients')}
                 />
-                {errors.ingredients && (
-                    <div id="error-ingredients" style={{ color: 'red' }}>
-                        {errors.ingredients.message}
-                    </div>
-                )}
             </div>
 
             <button type="submit" style={{ border: '2px solid black' }}>Add Recipe</button>
@@ -92,7 +87,7 @@ const AddRecipeForm = () => {
                     <ul>
                         {Object.entries(errors).map(([key, value]) => (
                             <li key={key} id={`error-${key}`}>
-                                {key}: {value?.message || 'Invalid input'}
+                                {value?.message || `${key}: Invalid input`}
                             </li>
                         ))}
                     </ul>


### PR DESCRIPTION
Recipe form:
- mark url and ingredients inputs required
- remove "optional" from url label
- remove duplicated display of errors for ingredients, enhance catch-all error message