### PR TITLE
Add pre-commit hook for lint and typecheck

### DIFF
--- a/hat-menu/.githooks/pre-commit
+++ b/hat-menu/.githooks/pre-commit
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+APP_DIR="$REPO_ROOT/hat-menu"
+
+if [ ! -f "$APP_DIR/package.json" ]; then
+  echo "Expected package.json at $APP_DIR/package.json but it was not found."
+  exit 1
+fi
+
+echo "--- Running ESlint Pre-Commit Hook ---"
+
+cd "$APP_DIR"
+
+npm run lint
+lint_status=$?
+
+if [ $lint_status -ne 0 ]; then
+  echo "ESLint failed with exit code $lint_status"
+  exit $lint_status
+fi
+
+echo "--- Running TypeScript Compiler Pre-Commit Hook ---"
+
+npx tsc --noEmit
+tsc_status=$?
+
+if [ $tsc_status -ne 0 ]; then
+  echo "TypeScript compilation check failed with exit code $tsc_status"
+  exit $tsc_status
+fi
+
+exit 0

--- a/hat-menu/package.json
+++ b/hat-menu/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "chmod +x .githooks/pre-commit && cp .githooks/pre-commit ../.git/hooks/ && chmod +x ../.git/hooks/pre-commit && echo 'Git hooks copied' && vite",
     "build": "tsc -b && vite build",
     "update-types": "npx supabase gen types --lang=typescript --project-id \"mhkyawszdfzvqpabtekd\" > src/schemas/database.types.ts",
     "lint": "eslint .",


### PR DESCRIPTION
To avoid mistakenly commit not linted and non-compiling code, let's use a pre commit hook to check.

Run ESLint and `tsc --noEmit` in hat-menu on pre-commit, and copy the hook into .git/hooks when starting the dev server.